### PR TITLE
Fix max_completion_tokens

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -209,7 +209,7 @@ type ChatCompletionRequest struct {
 	MaxTokens int `json:"max_tokens,omitempty"`
 	// MaxCompletionsTokens An upper bound for the number of tokens that can be generated for a completion,
 	// including visible output tokens and reasoning tokens https://platform.openai.com/docs/guides/reasoning
-	MaxCompletionsTokens int                           `json:"max_completions_tokens,omitempty"`
+	MaxCompletionsTokens int                           `json:"max_completion_tokens,omitempty"`
 	Temperature          float32                       `json:"temperature,omitempty"`
 	TopP                 float32                       `json:"top_p,omitempty"`
 	N                    int                           `json:"n,omitempty"`


### PR DESCRIPTION
The json tag is incorrect, and results in an error from the API when using the o1 model.  

I didn't modify the struct field name to maintain compatibility if anyone else had started using it, but it wouldn't work for them either.

A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/sashabaranov/go-openai/pulls) before creating one.

If your changes introduce breaking changes, please prefix the title of your pull request with "[BREAKING_CHANGES]". This allows for clear identification of such changes in the 'What's Changed' section on the release page, making it developer-friendly.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**Describe the change**
Please provide a clear and concise description of the changes you're proposing. Explain what problem it solves or what feature it adds.

**Provide OpenAI documentation link**
Provide a relevant API doc from https://platform.openai.com/docs/api-reference

**Describe your solution**
Describe how your changes address the problem or how they add the feature. This should include a brief description of your approach and any new libraries or dependencies you're using.

**Tests**
Briefly describe how you have tested these changes. If possible — please add integration tests.

**Additional context**
Add any other context or screenshots or logs about your pull request here. If the pull request relates to an open issue, please link to it.

Issue: #XXXX
